### PR TITLE
Update deps pyo3 symspell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symspell_rust"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 authors = ["zoho-labs"]
 keywords = ["spellcheck, symspell, rust, python, pyo3"]
@@ -22,8 +22,8 @@ name = "symspell_rust"
 crate-type = ["cdylib"]
 
 [dependencies]  
-symspell = "0.4.1"
+symspell = "0.4.3"
 
 [dependencies.pyo3]
-version = "0.8.5"
+version = "0.20.0"
 features = ["extension-module"]

--- a/install
+++ b/install
@@ -1,7 +1,5 @@
 you need to install rust before using symspell-rust package.
     - curl https://sh.rustup.rs -sSf | sh -s -- -y
     - source ~/.cargo/env
-    - rustup install nightly
-    - rustup default nightly
 And then do,
     - pip install symspell-rust

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="symspell_rust",
-    version="0.2.0",
+    version="0.3.0",
     description="Fast and Accurate SpellChecker",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     keywords="Symspell Spellchecker rust python_bind PyO3",

--- a/src/symspell_rust.rs
+++ b/src/symspell_rust.rs
@@ -2,7 +2,8 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 use pyo3::prelude::*;
-use pyo3::exceptions; 
+use pyo3::PyErr;
+use pyo3::exceptions::PyValueError;
 
 use symspell::{SymSpell, SymSpellBuilder, Verbosity, UnicodeStringStrategy};
 
@@ -60,11 +61,11 @@ pub struct SymspellPy {
 #[pymethods]
 impl SymspellPy {
     #[new]
-    fn new(obj: &PyRawObject,
+    fn new(
         max_distance:Option<i64>,
         prefix_length:Option<i64>,
         count_threshold:Option<i64>,
-        )->PyResult<()> { 
+        ) -> Self {
         
         let mut builder = SymSpellBuilder::default();
         if let Some(max_distance) = max_distance {
@@ -76,10 +77,11 @@ impl SymspellPy {
         if let Some(count_threshold) = count_threshold {
             builder.count_threshold(count_threshold);
             }
-            Ok(obj.init({SymspellPy{symspell: builder.build().unwrap()}})) 
+
+        SymspellPy{symspell: builder.build().unwrap()}
         }
 
-    
+
 
     fn load_dictionary(&mut self, file:&str, term_index:i64, count_index:i64, separator:&str) -> PyResult<bool> {
 
@@ -147,7 +149,7 @@ impl SymspellPy {
             0 => Verbosity::Top,
             1 => Verbosity::Closest,
             2 => Verbosity::All,
-            _ => return Err(exceptions::Exception::py_err("Verbosity must be between 0 and 2")),
+            _ => return Err(PyErr::new::<PyValueError, _>("Verbosity must be between 0 and 2")),
         };
 
         let res = self


### PR DESCRIPTION
Updates dependencies:
- `pyo3` -> `v0.20.0` (removes additional dependency on `nightly` rust toolchain)
- `symspell` -> `v0.4.3`

Updates existing `SymspellPy` class to use updated mechanism for creating new python objects.
- Removes references to `PyRawObj`; directly return `SymspellPy` struct.

Updates existing exception handling for out of range Verbosity to use `PyErr` and `PyValueError`.

Minor changes:
- Fixes a deprecation warning in setup.cfg
- Update `install` to remove notes about `nightly` toolchain